### PR TITLE
Clean up target containers with a stop and delete

### DIFF
--- a/app/jobs/docker_builder.rb
+++ b/app/jobs/docker_builder.rb
@@ -20,7 +20,8 @@ class DockerBuilder
   end
 
   def cleanup
-    container.kill(force: true) if container
+    container.stop(force: true) if container
+    container.delete(force: true) if container
     image.remove(force: true) if image
   rescue Exception => e
     puts "Error: #{e.to_s} #{e.backtrace}"


### PR DESCRIPTION
Kill was just killing the containerized process and nto having the
intended effect

The benchmark container is currently ran with `--rm` which does cleanup after itself already.

Fixes #15 