### PR TITLE
[WIP] Backend support for external project testing

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -18,7 +18,11 @@ class RepositoriesController < ApplicationController
 
   def build_latest
     @repository = current_user.repositories.find(params[:id])
-    build = @repository.build_from_last_commit
+    if @repository.is_external?
+      build = @repository.build_external
+    else
+      build = @repository.build_from_last_commit
+    end
     render json: build
   end
 

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -5,9 +5,6 @@ class WebhooksController < ApplicationController
   def hook
     build = Build.from_payload(params)
     build.save!
-    if ENV['GENERATE_DATA']
-      build.generate_fake_data(10)
-    end
     build.run_build
     render :text => 'OK', :status => 200
   end

--- a/app/jobs/empty_checkout.rb
+++ b/app/jobs/empty_checkout.rb
@@ -1,0 +1,24 @@
+class EmptyCheckout
+  def initialize(build)
+    @build = build
+  end
+
+  def retrieve
+    true
+  end
+
+  def source_dir
+  end
+
+  def project_configuration
+    parsed_conf = JSON.parse(@build.repository.config)
+    ProjectConfiguration.new(parsed_conf)
+  end
+
+  def errors
+    []
+  end
+
+  def cleanup
+  end
+end

--- a/app/jobs/external_builder.rb
+++ b/app/jobs/external_builder.rb
@@ -1,0 +1,21 @@
+class ExternalBuilder
+
+  def initialize(url, configuration)
+    @url = url
+  end
+
+  def cleanup
+  end
+
+  def build
+    true
+  end
+
+  def errors
+    []
+  end
+
+  def base_test_url
+    @url
+  end
+end

--- a/app/jobs/git_checkout.rb
+++ b/app/jobs/git_checkout.rb
@@ -14,8 +14,12 @@ class GitCheckout
     g.checkout(commit_hash) if commit_hash
     true
   rescue Exception => e
-    errors << e.to_s
+    errors << e.to_s + "\n#{e.backtrace}"
     false
+  end
+
+  def project_configuration
+    ProjectConfiguration.from_build_dir(source_dir)
   end
 
   def source_dir

--- a/app/jobs/orchestration_worker.rb
+++ b/app/jobs/orchestration_worker.rb
@@ -18,7 +18,8 @@ class OrchestrationWorker < Worker
     begin
       if build.repository.is_external?
         update_status(build, :preparing_target, 1)
-        test_configuration = ProjectConfiguration.new(build.repository.config)
+        parsed_conf = HashUtil.symbolize_keys(JSON.parse(build.repository.config))
+        test_configuration = ProjectConfiguration.new(parsed_conf)
         build_results.test_configuration = test_configuration
         unless test_configuration.valid?
           execution_error(build_results, test_configuration.errors)

--- a/app/jobs/project_configuration.rb
+++ b/app/jobs/project_configuration.rb
@@ -60,10 +60,6 @@ class ProjectConfiguration
     end
     port = config_hash['port']
     puts config_hash.to_json
-    unless port
-      errors << "Please specify a single 'port' to export"
-      return false
-    end
     @configuration = {
       endpoints: endpoints,
       port: port

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -96,20 +96,6 @@ class Build < ActiveRecord::Base
       build: self)
   end
 
-  def generate_fake_data(n)
-    (1..n).each do |i|
-      endpoint = add_endpoint("http://localhost:3000/api/endpoint#{i}", {})
-      data, score, avg_resp = fake_benchmarks(10)
-      endpoint_benchmark(endpoint, avg_resp, score, data)
-    end
-    mark_build_finished
-  end
-
-  def fake_benchmarks(n)
-    data = (1..n).map { rand(1000) }
-    [data, rand(11), data.inject(:+) / n.to_f]
-  end
-
   def self.message_for_status(status)
     case (status || '').to_sym
     when :cloning

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -114,6 +114,8 @@ class Build < ActiveRecord::Base
     case (status || '').to_sym
     when :cloning
       "Cloning Code"
+    when :preparing_target
+      "Remote Target Preparations"
     when :pending
       "Waiting to Build"
     when :building_container

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -10,7 +10,15 @@ class Build < ActiveRecord::Base
 
   #TODO: Fill this out
   def provider
-    :docker
+    if is_external?
+      :external
+    else
+      :docker
+    end
+  end
+
+  def is_external?
+    repository.is_external?
   end
 
   def self.from_payload(payload)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -67,6 +67,11 @@ class Repository < ActiveRecord::Base
       hook_options)
   end
 
+  def build_external
+    build = Build.create!(url: self.url, repository: self)
+    build.run_build
+  end
+
   def build_from_last_commit
     commits = user.github_client.commits(full_name)
     last_commit = commits[0]

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -78,7 +78,7 @@ class Repository < ActiveRecord::Base
     previous_commit = commits[1]
     previous_sha = previous_commit.sha
     last_sha = last_commit.sha
-    compare = "https://github.com/akira/testhook/compare/#{previous_sha[0..11]}...#{last_sha[0..11]}"
+    compare = "https://github.com/#{full_name}/compare/#{previous_sha[0..11]}...#{last_sha[0..11]}"
     if last_commit && previous_commit
       build = Build.create!(
         payload: '{}',
@@ -87,7 +87,7 @@ class Repository < ActiveRecord::Base
         after: last_sha,
         message: last_commit.commit.message,
         compare: compare,
-        url: "https://github.com/#{self.full_name}.git",
+        url: "https://github.com/#{full_name}.git",
         repository: self)
       build.run_build
     end


### PR DESCRIPTION
Provides #38 

I'd really appreciate an extra set of eyes on this changeset. 

I added a new method, `repository.build_external` rather than mucking about too much with the existing `repository.build_from_last_commit`.

I'm using the provided `repository.is_external?` to wrap a couple of things in the `OrchestrationWorker`.

Since external target projects don't need to provide a port to be mapped like Docker based target projects do, I just yanked out the test for that in the `ProjectConfiguration` job.

In my local testing, this appears to trigger a Vegeta benchmarking job against an external project configured through the GUI. However, the `results_overview` page may still need some work because I don't really see it updating.